### PR TITLE
Fix begin() for T4

### DIFF
--- a/FreqCount.cpp
+++ b/FreqCount.cpp
@@ -116,6 +116,7 @@ void FreqCountClass::begin(uint32_t usec)
   counter_init();
   timer_init(usec);
   //counter_start();
+  count_prev = 0;
 
 }
 


### PR DESCRIPTION
For Teensy 4, the variable count_prev is not set to zero upon calling FreqCount.begin(). This means that if FreqCount.begin() is called more than once in the code, the first reading after each FreqCount.begin() is not correct. I've added a line to clear count_prev which seems to solve the issue.